### PR TITLE
Fix \n and some translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Es können (ganz sicher) immer noch einige Übersetzungsfehler enthalten sein. D
 ### Wohin muss die .ini?
 `\Roberts Space Industries\StarCitizen\LIVE\data\Localization\german_(germany)`
 
-Außerdem musst du eine `user.cgf` im \LIVE\ Verzeichnis erstellen.
+Außerdem musst du eine `user.cfg` im \LIVE\ Verzeichnis erstellen.
 In diese Datei fügst du diese Zeile ein: `g_language = german_(germany)`

--- a/user.cfg
+++ b/user.cfg
@@ -1,0 +1,1 @@
+g_language = german_(germany)


### PR DESCRIPTION
Some \n were splitted to \ n (or were capitalized)

Going through some menus I noticed weird translations and fixed these 
some:
Attachements -> Anhänge -> Aufsätze
Baijini-Punkt -> Bajini Point
Ort -> Platzieren
Medizinischen Raum -> Behandlungsraum
interactionsmodus -> Interaktionsmodus
Griff (Med Wagen) -> Greifen
Kostenloser Blick -> Freies Umschauen
Kontext Speisekarte -> Kontext Menü
Ausführen -> Sprinten

--- Not sure about these---
Utility -> Dienstprogramm -> Nutzen (mir ist dafür nichts sinnvolleres eingefallen)
Herzfrequenz -> Schläge (was too long)