### PR TITLE
Täuschkörper, Cano System, Eigennamen

### DIFF
--- a/Eigennamen_Ubersetzungen.md
+++ b/Eigennamen_Ubersetzungen.md
@@ -62,3 +62,5 @@
 | Collision Alert High        | Kollisionsalarm oben           |                              |                    |
 | Collision Alert Port        | Kollisionsalarm links          | Kollisionsalarm backbord     |                    |
 | Collision Alert Starboard   | Kollisionsalarm rechts         | Kollisionsalarm steuerbord   |                    |
+| decoy                       | Hitzetäuschkörper              |                              |                    |
+| noise                       | Radartäuschkörper              | Scannertäuschkörper          |                    |

--- a/Eigennamen_Ubersetzungen.md
+++ b/Eigennamen_Ubersetzungen.md
@@ -1,0 +1,64 @@
+# Festlegung der Übersetzungen von Eigennamen
+
+| Englisch                    | Deutsch Variante 1             | Deutsch Variante 2           | Deutsch Variante 3 |
+|-----------------------------|:-------------------------------|------------------------------|--------------------|
+| wreckdiving                 | Wrackerkundung                 |                              |                    |
+| Hold your fire              | Feuer einstellen               |                              |                    |
+| Check your fire. Friendly.  | Feuer einstellen. Verbündeter! |                              |                    |
+| LIGHT GOODS                 | LEICHTE FRACHT                 |                              |                    |
+| Fuel Pod Summary            | Treibstoffbehälter             |                              |                    |
+| Friendly down               | Verbündeter am Boden           |                              |                    |
+| Hostiles inbound            | Feindliche Einheiten im Anflug |                              |                    |
+| Look alive                  | Seid wachsam                   | Seid aufmerksam              |                    |
+| Look sharp people           | Seid wachsam                   | Seid aufmerksam              |                    |
+| Quantum-Snare               | Quantumfalle                   |                              |                    |
+| Sub-Item Slot               | Zusatzkomponenten-Slot         |                              |                    |
+| Missile Rack                | Raketengestell                 |                              |                    |
+| Remote Turret               | Ferngesteuertes Geschütz       |                              |                    |
+| Barrel                      | Lauf                           |                              |                    |
+| Avionics                    | Avionik                        | Avioniksystem                |                    |
+| Utility                     | Hilfsmittel                    |                              |                    |
+| Spare Weapon Magazine       | Ersatzmagazin                  |                              |                    |
+| Missile Attach Point        | Raketenaufsatzpunkt            |                              |                    |
+| Optics Attachment           | Zieloptik-Aufsätze             |                              |                    |
+| Attachment                  | Aufsatz                        |                              |                    |
+| Utility Item                | Gebrauchsgegenstand            |                              |                    |
+| Consumable                  | Verbrauchsgut                  |                              |                    |
+| Sidearm                     | Handfeuerwaffe                 |                              |                    |
+| Stored Throwables           | Verstaute Wurfgegenstände      |                              |                    |
+| Inner Thought               | innerer Dialog                 |                              |                    |
+| Power Triangle Assignment   | Leistungsdreieck-Zuweisung     |                              |                    |
+| Pitch                       | Nickachse                      | Nicken                       |                    |
+| Roll                        | Rollachse                      | Rollen                       |                    |
+| Yaw                         | Gierachse                      | Gieren                       |                    |
+| CYCLE                       | Wechseln                       | durchwechseln                | durchschalten      |
+| Item                        | Gegenstand                     |                              |                    |
+| Credit                      | Geld                           | Scheine                      | Moneten            |
+| Credits                     | Geld                           | Scheine                      | Moneten            |
+| Friendly Fire               | Friendly Fire                  |                              |                    |
+| Rear Shield                 | hintere Schilde                | Achterschilde                |                    |
+| Deck Shield                 | untere Schilde                 |                              |                    |
+| Shields Recharging          | Schilde regenerieren           |                              |                    |
+| Head Shield                 | vordere Schilde                |                              |                    |
+| Shields up                  | Schilde sind oben              |                              |                    |
+| Port shield                 | linke Schilde                  | Backbordschilde              |                    |
+| Starboard shield            | rechte Schilde                 | Steuerbordschilde            |                    |
+| Overhead shield             | obere Schilde                  |                              |                    |
+| Aft Proximity Alert         | Annäherungsalarm hinten        | Annäherungsalarm achtern     |                    |
+| Deck Proximity Alert        | Annäherungsalarm unten         |                              |                    |
+| Forward Proximity Alert     | Annäherungsalarm vorne         |                              |                    |
+| Overhead Proximity Alert    | Annäherungsalarm oben          |                              |                    |
+| Port Proximity Alert        | Annäherungsalarm links         | Annäherungsalarm backbord    |                    |
+| Starboard Proximity Alert   | Annäherungsalarm rechts        | Annäherungsalarm steuerbord  |
+| Warning Collision Stern     | Achtung Kollision hinten       | Achtung Kollision achtern    |                    |
+| Warning Collision Nadir     | Achtung Kollision unten        |                              |                    |
+| Warning Collision Fore      | Achtung Kollision vorne        |                              |                    |
+| Warning Collision Zenith    | Achtung Kollision oben         |                              |                    |
+| Warning Collision Port      | Achtung Kollision links        | Achtung Kollision backbord   |                    |
+| Warning Collision Starboard | Achtung Kollision rechts       | Achtung Kollision steuerbord |                    |
+| Collision Alert Rear        | Kollisionsalarm hinten         | Kollisionsalarm achtern      |                    |
+| Collision Alert Low         | Kollisionsalarm unten          |                              |                    |
+| Collision Alert Front       | Kollisionsalarm vorne          |                              |                    |
+| Collision Alert High        | Kollisionsalarm oben           |                              |                    |
+| Collision Alert Port        | Kollisionsalarm links          | Kollisionsalarm backbord     |                    |
+| Collision Alert Starboard   | Kollisionsalarm rechts         | Kollisionsalarm steuerbord   |                    |


### PR DESCRIPTION
* Umbenennung von decoy und noise

  * decoy = Hitzetäuschkörper
  * noise = Radartäuschkörper

  * HUD Elemente sind aus Platzgründen weiterhin Englisch.
* Korrektur Beschreibungen Cano System
* Eigennamen_Ubersetzungen.md