### PR TITLE
Dynamischer Release-Titel

### DIFF
--- a/.github/workflows/create_realease.yml
+++ b/.github/workflows/create_realease.yml
@@ -11,14 +11,11 @@
 # 6. create the release
 
 on:
-  workflow_dispatch: # used only for testing to trigger the workflow from the GitHub website
+  workflow_dispatch: # used only to manually trigger the workflow from the GitHub website
     inputs:
-      logLevel:
-        description: 'Log Level'
-        required: true
-        default: 'warning'
-      tags:
-        description: 'Test Scenario Tags'
+      tag:
+        description: "Release Tag"
+        type: string
   schedule:
     - cron: "0 3 * * *"
 
@@ -118,7 +115,7 @@ jobs:
       - name: Create Release For LIVE
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ needs.get_context_info.outputs.DATE }}-LIVE
+          tag: ${{ inputs.tag || needs.get_context_info.outputs.DATE }}-LIVE
           commit: main
           name: ${{ needs.get_context_info.outputs.RELEASE_TITLE_LIVE }}
           body: ${{ vars.RELEASE_BODY_LIVE }}
@@ -128,7 +125,7 @@ jobs:
     name: Create PTU Release
     runs-on: ubuntu-latest
     needs: [get_context_info, live_release]
-    if: ${{ always() }} && (vars.TRIGGER_PTU_RELEASE == 1 && (needs.get_context_info.outputs.NEW_COMMIT_COUNT_PTU > 0))
+    if: always() && vars.TRIGGER_PTU_RELEASE == 1 && (needs.get_context_info.outputs.NEW_COMMIT_COUNT_PTU > 0)
     permissions:
       contents: write
     steps:
@@ -149,7 +146,7 @@ jobs:
       - name: Create Release For PTU
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ needs.get_context_info.outputs.DATE }}-PTU
+          tag: ${{ inputs.tag || needs.get_context_info.outputs.DATE }}-PTU
           commit: main
           name: ${{ needs.get_context_info.outputs.RELEASE_TITLE_PTU }}
           body: ${{ vars.RELEASE_BODY_PTU }}


### PR DESCRIPTION
Der Release Titel wird aus dem Titel des letzten Commits generiert, der die entsprechende ini geändert hat.

Erwartet einen Commit-Titel in der Form `3.22.0-PTU.8976730 | Neuer Build (#299)` und nimmt die Versionsnummer (hier 3.22.0_PTU.8976730) und generiert daraus den Release-Titel `Star Citizen 3.22.0-PTU.8976730 [de]`. Es muss zwingend ein `|` als Trennzeichen eingesetzt werden und zwischen der Versionsnummer und dem Trennzeichen ein Leerzeichen sein.

Wie die Versionsnummer vor dem Trennzeichen aufgebaut ist (z. B. mit _ oder -) und wie lang sie ist, ist egal.

@MaxM1211 teste es gerne in deinem Fork noch mal. Habe die Änderungen an deinen Aufbau angepasst, sollte so passen.

Wichtig ist es dann für alle, die PR mergen, darauf zu achten, dass der Merge-Commit einen konformen Titel hat.