### PR TITLE
Titel des Releases verkürzt

### DIFF
--- a/.github/workflows/create_realease.yml
+++ b/.github/workflows/create_realease.yml
@@ -81,7 +81,7 @@ jobs:
           then
           echo "RELEASE_TITLE_LIVE=${{ vars.RELEASE_TITLE_LIVE }}" >> $GITHUB_OUTPUT
           else
-          echo "RELEASE_TITLE_LIVE=Star Citizen $(git log -1 --pretty=%s -- live/global.ini | cut -s -d'|' -f1 | rev | cut -c 2- | rev) [de]" >> $GITHUB_OUTPUT
+          echo "RELEASE_TITLE_LIVE=$(git log -1 --pretty=%s -- live/global.ini | cut -s -d'|' -f1 | rev | cut -c 2- | rev) [de]" >> $GITHUB_OUTPUT
           fi
 
       - name: Create Release Title For PTU
@@ -92,7 +92,7 @@ jobs:
           then
           echo "RELEASE_TITLE_PTU=${{ vars.RELEASE_TITLE_PTU }}" >> $GITHUB_OUTPUT
           else
-          echo "RELEASE_TITLE_PTU=Star Citizen $(git log -1 --pretty=%s -- ptu/global.ini | cut -s -d'|' -f1 | rev | cut -c 2- | rev) [de]" >> $GITHUB_OUTPUT
+          echo "RELEASE_TITLE_PTU=$(git log -1 --pretty=%s -- ptu/global.ini | cut -s -d'|' -f1 | rev | cut -c 2- | rev) [de]" >> $GITHUB_OUTPUT
           fi
 
       - name: Get Last Tag On LIVE


### PR DESCRIPTION
Den "Star Citizen" Text aus dem Titel entfernt. Brauchen wir eigentlich.