### PR TITLE
Update Festlegungen.md

### DIFF
--- a/docs_tools/Festlegungen.md
+++ b/docs_tools/Festlegungen.md
@@ -90,7 +90,6 @@ Es ist ein lebendes Dokument, dass bei Übereinkunft im Team jederzeit angepasst
 | Englisch                             | Deutsch Variante 1             | Deutsch Variante 2                                                                | Deutsch Variante 3          |
 |:-------------------------------------|:-------------------------------|:----------------------------------------------------------------------------------|:----------------------------|
 | `Quantum Drive`                      | `Quantumantrieb`               |                                                                                   |                             |
-| `Quantum Snare`                      | `Quantumfalle`                 |                                                                                   |                             |
 | `Quantum Travel`                     | `Quantumreise`                 | `Quantumjump` (je nach Kontext)                                                   |                             |
 | `Avionics`                           | `Avionik`                      | `Avioniksystem`                                                                   |                             |
 | `Thruster`                           | `Triebwerk`                    | `Schubdüse`                                                                       |                             |


### PR DESCRIPTION
- Der Eintrag zu `Quantum-Falle` entfernt. Ich würde es in `Quantum-Snare` belassen.
- Genau so wie `Quantum-Dämpfer` (hier nicht eingetragen) das `Quantum-Dampener` bleiben sollte.