### PR TITLE
Revert release title generation logic

### DIFF
--- a/.github/workflows/create_realease.yml
+++ b/.github/workflows/create_realease.yml
@@ -76,12 +76,26 @@ jobs:
       - name: Create Release Title For PTU
         id: title_ptu # creates a title for the release that shows the version number used in the title of the last commit that changed the ptu/global.ini
         if: steps.new_commits_ptu.outputs.NEW_COMMIT_COUNT_PTU > 0
-        run: echo "RELEASE_TITLE_PTU=$(cat 'en/ptu/build.ptu')" >> $GITHUB_OUTPUT
+#        run: echo "RELEASE_TITLE_PTU=$(cat 'en/ptu/build.ptu')" >> $GITHUB_OUTPUT
+        run: |
+          if [$(git log -1 --pretty=%s -- ptu/global.ini | grep "|") == ""]
+          then
+          echo "RELEASE_TITLE_PTU=${{ vars.RELEASE_TITLE_PTU }}" >> $GITHUB_OUTPUT
+          else
+          echo "RELEASE_TITLE_PTU=$(git log -1 --pretty=%s -- ptu/global.ini | cut -s -d'|' -f1 | rev | cut -c 2- | rev) [de]" >> $GITHUB_OUTPUT
+          fi
 
       - name: Create Release Title For LIVE
         id: title_live # creates a title for the release that shows the version number used in the title of the last commit that changed the live/global.ini
         if: steps.new_commits_live.outputs.NEW_COMMIT_COUNT_LIVE > 0
-        run: echo "RELEASE_TITLE_LIVE=$(cat 'en/live/build.live')" >> $GITHUB_OUTPUT
+#        run: echo "RELEASE_TITLE_LIVE=$(cat 'en/live/build.live')" >> $GITHUB_OUTPUT
+        run: |
+          if [$(git log -1 --pretty=%s -- live/global.ini | grep "|") == ""]
+          then
+          echo "RELEASE_TITLE_LIVE=${{ vars.RELEASE_TITLE_LIVE }}" >> $GITHUB_OUTPUT
+          else
+          echo "RELEASE_TITLE_LIVE=$(git log -1 --pretty=%s -- live/global.ini | cut -s -d'|' -f1 | rev | cut -c 2- | rev) [de]" >> $GITHUB_OUTPUT
+          fi
 
       - name: Get Last Tag On PTU
         id: tag_PTU


### PR DESCRIPTION
The commit updates the release title generation script for both PTU and LIVE environments. It now uses the latest commit message to extract the title, handling cases where a pipe character is present and appending a locale indicator when needed.

Auf Wunsch von @rjcncpt wieder auf alte Methode zurückgesetzt.