### PR TITLE
Remove or update Tests for PTU

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Fehlermeldung
-about: Erstelle eine Fehlermeldung über eine falsche oder verbeserungswürdige Übersetzung.
+about: Erstelle eine Fehlermeldung über eine falsche oder verbesserungswürdige Übersetzung.
 title: ""
 labels: Fehler
 assignees: ""
@@ -24,4 +24,4 @@ Wenn möglich, füge Screenshots ein, damit wir den Fehler direkt sehen und eino
 - Build: [z.B. 8854374]
 
 ### Zusätzlicher Kontext
-Jegliche weitere Informationen die uns helfen können den Kontext zu verstehen.
+Jegliche weitere Informationen, die uns helfen können, den Kontext zu verstehen.

--- a/.github/tests/bracket_test.py
+++ b/.github/tests/bracket_test.py
@@ -38,12 +38,13 @@ def check_brackets(filename, excluded):
 
 
 if __name__ == "__main__":
-    excluded_lines = [44749, 44750, 46617, 46654]
+    excluded_lines_live = [41119, 44802, 44803, 46672, 46709, 46152]
+    excluded_lines_ptu = [41610, 45442, 45443, 47387, 47424, 46865]
     deu_live_file = "live/global.ini"
     deu_ptu_file = "ptu/global.ini"
     print()
     print(f"Checking {deu_live_file}...")
-    check_brackets(deu_live_file, excluded_lines)
+    check_brackets(deu_live_file, excluded_lines_live)
     print()
     print(f"Checking {deu_ptu_file}...")
-    check_brackets(deu_ptu_file, excluded_lines)
+    check_brackets(deu_ptu_file, excluded_lines_ptu)

--- a/.github/tests/encoding_test.py
+++ b/.github/tests/encoding_test.py
@@ -27,8 +27,8 @@ file_deu_ptu = "ptu/global.ini"
 
 type_eng_live = get_type(file_eng_live)
 type_deu_live = get_type(file_deu_live)
-type_eng_ptu = get_type(file_eng_ptu)
-type_deu_ptu = get_type(file_deu_ptu)
+# type_eng_ptu = get_type(file_eng_ptu)
+# type_deu_ptu = get_type(file_deu_ptu)
 
 exit_code = 0
 
@@ -40,12 +40,12 @@ if type_eng_live["encoding"] != type_deu_live["encoding"]:
 else:
     print("The encoding between the LIVE files matches.")
 
-if type_eng_ptu["encoding"] != type_deu_ptu["encoding"]:
-    print("The encoding between the PTU INI files differs!")
-    print(f"Encoding ENG: {type_eng_ptu['encoding']}")
-    print(f"Encoding DEU: {type_deu_ptu['encoding']}")
-    exit_code = 1
-else:
-    print("The encoding between the PTU files matches.")
+# if type_eng_ptu["encoding"] != type_deu_ptu["encoding"]:
+#     print("The encoding between the PTU INI files differs!")
+#     print(f"Encoding ENG: {type_eng_ptu['encoding']}")
+#     print(f"Encoding DEU: {type_deu_ptu['encoding']}")
+#     exit_code = 1
+# else:
+#     print("The encoding between the PTU files matches.")
 
 exit(exit_code)

--- a/.github/tests/key_test.py
+++ b/.github/tests/key_test.py
@@ -27,8 +27,8 @@ def keys_in_second_ini(first_file, second_file):
 # Files to be checked
 eng_live_file = "en/live/global.ini"
 deu_live_file = "live/global.ini"
-eng_ptu_file = "en/ptu/global.ini"
-deu_ptu_file = "ptu/global.ini"
+# eng_ptu_file = "en/ptu/global.ini"
+# deu_ptu_file = "ptu/global.ini"
 
 exit_code = 0
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Test- und Preview-Kanäle werden von uns nicht unterstützt. Damit du an den Tes
 
 <details>
 <summary>[Klick] Fehler: Es werden kryptische Variablen mit @-Zeichen am Anfang angezeigt</summary>
-Unsere **`global.ini`** Datei liegt bereits im korrekten **`UTF-8-BOM`** im Format vor. Wenn bei dir Variablen angezeigt werden, die mit einem @-Zeichen beginnen, aber die Ordnerstuktur richtig ist, scheint deine Datei-Codierung falsch zu sein. Lade entweder **[unsere Datei erneut herunter](https://github.com/rjcncpt/StarCitizen-Deutsch-INI/blob/main/live/global.ini)** oder stelle die Codierung deiner Datei manuell um:
+Unsere **`global.ini`** Datei liegt bereits im korrekten **`UTF-8-BOM`** im Format vor. Wenn bei dir Variablen angezeigt werden, die mit einem @-Zeichen beginnen, aber die Ordnerstruktur richtig ist, scheint deine Datei-Codierung falsch zu sein. Lade entweder **[unsere Datei erneut herunter](https://github.com/rjcncpt/StarCitizen-Deutsch-INI/blob/main/live/global.ini)** oder stelle die Codierung deiner Datei manuell um:
 <br/><br/>
 
 1. Öffne die **`global.ini`** in einem Texteditor wie Notepad++ (kostenlos)
@@ -117,12 +117,12 @@ Das sollte das Problem beheben.
 Achte bei den beiden Dateien **`global.ini`** und **`user.cfg`** auf die richtigen Dateiendungen.
 <br/><br/>
 
-Kontrolliere ob es die richtige Dateiendung ist:
+Kontrolliere, ob es die richtige Dateiendung ist:
 
 1. Öffne den Windows Dateiexplorer
 2. Klicke auf Ansicht am oberen Fensterrand
 3. Aktiviere im Bereich Ein-/ausblenden: **`Dateinamenerweiterungen`**
-4. Sollten die beiden Dateien nun **`global.ini.ini`** oder **`user.txt.cfg`** oder ähnlich heißen, musst du sie zurück in **`global.ini`** und **`user.cfg`** umbennenen.
+4. Sollten die beiden Dateien nun **`global.ini.ini`** oder **`user.txt.cfg`** oder ähnlich heißen, musst du sie zurück in **`global.ini`** und **`user.cfg`** umbennennen.
    <br/><br/>
 
 Das sollte das Problem beheben.
@@ -135,7 +135,7 @@ Das sollte das Problem beheben.
 
 <details>
 <summary>[Klick] Fehler: Keine englische Sprachausgabe im Spiel</summary>
-Es gibt einen Fix für das Audio Problem. Du musst deiner **`user.cfg`** Datei diese folgende Zeile hinzufügen:<br/>
+Es gibt einen Fix für das Audioproblem. Du musst deiner **`user.cfg`** Datei diese folgende Zeile hinzufügen:<br/>
 **`g_languageAudio = english`**<br/><br/>
 Alternativ lade dir unsere **`user.cfg`** Datei herunter, in der wir das bereits für dich übernommen haben.
 <br/><br/>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 #### Es ist davon auszugehen, dass eine deutsche Übersetzung das Tor für potenziell tausende und langfristig für Millionen neuer Spieler öffnet und einlädt, Star Citizen zu testen.
 
-**Sollte es noch zu seltsamen Übersetzungen kommen, kannst du sehr gerne [eine Diskussion eröffnen](https://github.com/rjcncpt/StarCitizen-Deutsch-INI/discussions/categories/%C3%BCbersetzungsvorschl%C3%A4ge) oder [einen Issue schreiben](https://github.com/rjcncpt/StarCitizen-Deutsch-INI/issues/new?assignees=&labels=Fehler&projects=&template=bug_report.md&title=), deinen Vorschlag posten und ein Teil der Übersetzung werden.**
+**Sollte es noch zu seltsamen Übersetzungen kommen, kannst du sehr gerne [eine Diskussion eröffnen](https://github.com/rjcncpt/StarCitizen-Deutsch-INI/discussions/categories/%C3%BCbersetzungsvorschl%C3%A4ge) oder [ein Issue schreiben](https://github.com/rjcncpt/StarCitizen-Deutsch-INI/issues/new?assignees=&labels=Fehler&projects=&template=bug_report.md&title=), deinen Vorschlag posten und ein Teil der Übersetzung werden.**
 
 <br/>
 

--- a/docs_tools/Festlegungen.md
+++ b/docs_tools/Festlegungen.md
@@ -1,7 +1,7 @@
 ### Vorwort
 
 Hier werden grundlegende Festlegungen für die Übersetzungen getroffen.
-Es ist ein lebendes Dokument, dass bei Übereinkunft im Team jederzeit angepasst werden kann.
+Es ist ein lebendes Dokument, das bei Übereinkunft im Team jederzeit angepasst werden kann.
 
 ### Allgemein
 

--- a/docs_tools/symbolic_link/readme.md
+++ b/docs_tools/symbolic_link/readme.md
@@ -1,6 +1,6 @@
 # Symbolic Link vom LIVE Ordner erstellen
 
-Der ständige Download von vielen Gigabyte Daten wenn man zwischen LIVE und PTU wechselt, ist unnötig. Erstelle mit einem winzigen Tool eine symbolische Verknüpfung des LIVE Verzeichnis und spare dir Zeit. Ein "Symbolic Link" ist nichts anderes als eine Verknüpfung, funktioniert jedoch anders.
+Der ständige Download von vielen Gigabyte Daten, wenn man zwischen LIVE und PTU wechselt, ist unnötig. Erstelle mit einem winzigen Tool eine symbolische Verknüpfung des LIVE Verzeichnisses und spare dir Zeit. Ein "Symbolic Link" ist nichts anderes als eine Verknüpfung, funktioniert jedoch anders.
 
 ![image](https://i.imgur.com/HrASh6V.png)
 
@@ -8,10 +8,10 @@ Der ständige Download von vielen Gigabyte Daten wenn man zwischen LIVE und PTU 
 
 - Ein Symbolic Link für einen Ordner ist eine Verknüpfung zu einem Verzeichnis, die einen Pfad zu einem anderen Verzeichnis darstellt.
 - Symbolic Links können auf andere Laufwerke oder Netzwerkpfade verweisen.
-- Änderungen am Zielordner beeinflussen den Symbolic Link, und umgekehrt.
+- Änderungen am Zielordner beeinflussen den Symbolic Link und umgekehrt.
 - Symbolic Links sind flexibler, da sie auf nicht existierende Pfade zeigen können.
 
-### So gehts
+### So geht's
 
 1. Lade dir das Tool herunter: https://sourceforge.net/projects/symlink-creator/
 2. Öffne die `SymlinkCreator.exe`
@@ -20,15 +20,15 @@ Der ständige Download von vielen Gigabyte Daten wenn man zwischen LIVE und PTU 
 5. **Source (Target):** Wähle das Quellverzeichnis. In diesem Fall LIVE
 6. Klicke auf **Create Link**
 
-<br/>Wenn du alles richtig gemacht hast und alle Verknüpfungen erstellt hast die du brauchst, sollte es wie bei mir aussehen.
+<br/>Wenn du alles richtig gemacht hast und alle Verknüpfungen erstellt hast, die du brauchst, sollte es wie bei mir aussehen.
 
 ![image](https://i.imgur.com/VAsoJBz.png)
 
-<br/>Jetzt brauchst du im RSI-Launcher nur noch die entsprechende Testumgebung auswählten und es werden immer nur die fehlenden Daten installiert, weil die Grundlage der symbolischen Verknüpfung der LIVE Ordner ist. Damit entfällt das Umbenennen oder Kopieren der Ordner.
+<br/>Jetzt brauchst du im RSI-Launcher nur noch die entsprechende Testumgebung auswählen und es werden immer nur die fehlenden Daten installiert, weil die Grundlage der symbolischen Verknüpfung der LIVE Ordner ist. Damit entfällt das Umbenennen oder Kopieren der Ordner.
 
 ![image](https://i.imgur.com/cEVsdeS.png)
 
 <br/><br/>
 ### Wichtiger Hinweis
 
-Wenn du die Reihenfolge im Tool vertauchst, löschst du den LIVE Ordner. Also achte auf Quell -und Ziel-Verzeichnis. Orientiere dich an meinem Screenshot.
+Wenn du die Reihenfolge im Tool vertauschst, löschst du den LIVE Ordner. Also achte auf Quell- und Zielverzeichnis. Orientiere dich an meinem Screenshot.

--- a/docs_tools/updater/readme.md
+++ b/docs_tools/updater/readme.md
@@ -2,7 +2,7 @@
 
 Diese Datei(en) ermöglichen es dir auf einfachste Weise, vor jedem RSI-Launcher Start ein Update der aktuellen Übersetzungsdatei durchzuführen. Bevor du startest, musst du ein paar Schritte durchführen. Nach dem ini-Update startet der RSI-Launcher automatisch.
 
-### So gehts
+### So geht's
 
 1. Lade dir die Datei(en) herunter
 2. Speichere die Datei(en) in den Spielordner
@@ -16,16 +16,16 @@ Diese Datei(en) ermöglichen es dir auf einfachste Weise, vor jedem RSI-Launcher
 
 ### Das Icon ändern
 
-1. Erstelle eine Verknüfung der Datei(en)
+1. Erstelle eine Verknüpfung der Datei(en)
 2. Klicke mit der rechten Maustaste auf die Datei(en) und wähle `Eigenschaften` aus
-3. Wähle `Anderes Symbol` -> `Duchsuchen` und suche dir ein Icon aus
+3. Wähle `Anderes Symbol` ⇾ `Duchsuchen` und suche dir ein Icon aus
 
-Tipp: Verwende die Spiel-Icons. Navigiere zum Star Citizen Ordner, um das SC Icon zu verwenden, oder zum RSI Launcher, um das Launcher Icon zu verwenden
+Tipp: Verwende die Spiel-Icons. Navigiere zum Star Citizen Ordner, um das SC Icon zu verwenden, oder zum RSI Launcher, um das Launcher Icon zu verwenden.
 <br/><br/><br/><br/>
 
 # SC Launch Configurator
 
-**<p>Eine andere Möglichkeit unsere Übersetzungsdatei für Star Citizen automatisch zu updaten, bietet der kostenlose [SC Launch Configurator](https://www.luftwerft.com/) von Luftwerft.</p>**
+**<p>Eine andere Möglichkeit, unsere Übersetzungsdatei für Star Citizen automatisch zu updaten, bietet der kostenlose [SC Launch Configurator](https://www.luftwerft.com/) von Luftwerft.</p>**
 
 ![image](https://www.luftwerft.com/images/sclc_en.png)
 

--- a/en/Hinweis.txt
+++ b/en/Hinweis.txt
@@ -1,6 +1,6 @@
 SUPPORT FÜR ORIGINALE PTU INI-DATEI EINGESTELLT
 
-Wir haben beschlossen, die Veröffentlichung der englischen PTU INI-Datei einzustellen. In der Vergangenheit kam es gelegentlich vor, dass wir vergessen haben, diese Datei zu aktualisieren, und da die deutsche Übersetzung bereits eine anspruchsvolle Aufgabe darstellt und wir uns nicht um zusätzliche fehlerfaktoren kümmern möchten, haben wir uns dazu entschlossen, diesen Schritt zu gehen. Dies ermöglicht es uns, unsere Ressourcen effizienter zu nutzen und sicherzustellen, dass unsere deutschen Spieler den bestmöglichen Support erhalten.
+Wir haben beschlossen, die Veröffentlichung der englischen PTU INI-Datei einzustellen. In der Vergangenheit kam es gelegentlich vor, dass wir vergessen haben, diese Datei zu aktualisieren, und da die deutsche Übersetzung bereits eine anspruchsvolle Aufgabe darstellt und wir uns nicht um zusätzliche Fehlerfaktoren kümmern möchten, haben wir uns dazu entschlossen, diesen Schritt zu gehen. Dies ermöglicht es uns, unsere Ressourcen effizienter zu nutzen und sicherzustellen, dass unsere deutschen Spieler den bestmöglichen Support erhalten.
 
 Danke für dein Verständnis und deine fortlaufende Unterstützung!
 


### PR DESCRIPTION
Durch das Entfernen der eng ptu ini müssen ein paar Tests deaktiviert werden. 

Im Zuge dessen habe ich auch die anderen Tests kontrolliert.
Insb. der bracket test war schon länger nicht mehr korrekt. Es schlägt aber nicht fehl, da kein `exit(1)` verwendet wird. (Denke das war so beabsichtigt ?!)

Den encoding test könnte man alternativ umschreiben und die ptu ini mit der eng live ini gegentesten. Kein Plan, ob wir das machen sollten. 
Irgendeine Meinung zum letzten Punkt @rjcncpt ?

Edit:
Ich habe noch ein paar Rechtschreibfehler und Grammatikfehler gefunden und gefixt. :-D