### PR TITLE
bracket_test.py | Ausschlussliste von Zeilennummer zu Präfix

### DIFF
--- a/.github/tests/bracket_test.py
+++ b/.github/tests/bracket_test.py
@@ -1,50 +1,59 @@
 import re
 
+# Definition der auszuschließenden Präfixe
+excluded_prefixes = {
+    "live": [
+        "test_prefix=",
+        "ignore_this=",
+        "skip_line=",
+    ],
+    "ptu": [
+        "exclude_this=",
+        "ptu_ignore=",
+    ]
+}
 
-def check_brackets(filename, excluded):
+
+def check_brackets(filename, excluded_prefixes):
     """
-    :param filename: The name of the file to check for bracket matching.
-    :param excluded: A list of line numbers to exclude from checking.
+    :param filename: Der Name der Datei, die auf Klammerpaare überprüft wird.
+    :param excluded_prefixes: Liste von Präfixen, deren Zeilen übersprungen werden.
     :return: None
 
-    The check_brackets method reads the contents of the given file and checks for matching brackets. It skips the lines specified in the 'excluded' parameter. If any mismatched or unclosed
-    * brackets are found, an error message is printed with the line number.
-
-    Example usage:
-
-    check_brackets('file.txt', [3, 5, 7])
-
-    This will check the contents of 'file.txt' for bracket matching, excluding lines 3, 5, and 7.
+    Überprüft die Datei auf korrektes Klammerpaar-Matching, ignoriert Zeilen, die mit bestimmten Präfixen beginnen.
     """
     with open(filename, 'r', encoding="UTF-8-SIG") as file:
         for line_number, line in enumerate(file, start=1):
-            if line_number not in excluded:
-                # Remove enumerations and smileys
-                clean_line = re.sub(r'\d\.\)|\s[a-z]\)|:\)', '', line)  # This regex should filter all "1.)" "a)" and ":)" parts.
+            # Überspringe Zeilen mit ausgeschlossenen Präfixen
+            if any(line.startswith(prefix) for prefix in excluded_prefixes):
+                continue
 
-                bracket_stack = []
-                for char in clean_line:
-                    if char == '(':
-                        bracket_stack.append(char)
-                    elif char == ')':
-                        try:
-                            bracket_stack.pop()
-                        except IndexError:
-                            print(f"Line {line_number}: Extra closing bracket detected.")
-                            break
+            # Bereinige die Zeile von unerwünschten Teilen
+            clean_line = re.sub(r'\d\.\)|\s[a-z]\)|:\)', '', line)  # Entferne "1.)", "a)", ":)" Teile.
 
-                if bracket_stack:
-                    print(f"Line {line_number}: Open bracket is not closed.")
+            bracket_stack = []
+            for char in clean_line:
+                if char == '(':
+                    bracket_stack.append(char)
+                elif char == ')':
+                    try:
+                        bracket_stack.pop()
+                    except IndexError:
+                        print(f"Zeile {line_number}: Zusätzliche schließende Klammer gefunden.")
+                        break
+
+            if bracket_stack:
+                print(f"Zeile {line_number}: Offene Klammer wurde nicht geschlossen.")
 
 
 if __name__ == "__main__":
-    excluded_lines_live = [41119, 44802, 44803, 46672, 46709, 46152]
-    excluded_lines_ptu = [41610, 45442, 45443, 47387, 47424, 46865]
+    # Dateien für live und ptu
     deu_live_file = "live/global.ini"
     deu_ptu_file = "ptu/global.ini"
+
     print()
-    print(f"Checking {deu_live_file}...")
-    check_brackets(deu_live_file, excluded_lines_live)
+    print(f"Prüfe {deu_live_file}...")
+    check_brackets(deu_live_file, excluded_prefixes["live"])
     print()
-    print(f"Checking {deu_ptu_file}...")
-    check_brackets(deu_ptu_file, excluded_lines_ptu)
+    print(f"Prüfe {deu_ptu_file}...")
+    check_brackets(deu_ptu_file, excluded_prefixes["ptu"])


### PR DESCRIPTION
Ich habe mal die Ausschlussliste von Zeilennummern zu Präfixe geändert. Die Zeilennummern dürften sich ja mittlerweile mehrfach geändert haben. Was auch bedeutet, dass ich keine Ahnung habe welche Zeilen das damals waren und ob das noch relevant ist.