### PR TITLE
Update create_realease.yml | Workflow alle 14 Tage

### DIFF
--- a/.github/workflows/create_realease.yml
+++ b/.github/workflows/create_realease.yml
@@ -12,13 +12,13 @@
 
 name: Create Releases
 on:
-  workflow_dispatch: # used only to manually trigger the workflow from the GitHub website
+  workflow_dispatch:
     inputs:
       tag:
         description: "Release Tag"
         type: string
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "0 3 */14 * *"
 jobs:
   get_context_info:
     name: Get Context Info
@@ -27,6 +27,7 @@ jobs:
       DATE: ${{ steps.date.outputs.DATE }}
       DATE_REV: ${{ steps.date_rev.outputs.DATE_REV }}
       TIME: ${{ steps.time.outputs.TIME }}
+      MONTH: ${{ steps.month.outputs.MONTH }}
       NEW_COMMIT_COUNT_PTU: ${{ steps.new_commits_ptu.outputs.NEW_COMMIT_COUNT_PTU }}
       NEW_COMMIT_COUNT_LIVE: ${{ steps.new_commits_live.outputs.NEW_COMMIT_COUNT_LIVE }}
       COMMIT_PTU: ${{ steps.commit_ptu.outputs.COMMIT_PTU }}
@@ -57,80 +58,25 @@ jobs:
         id: time
         run: echo "TIME=$(date '+%H:%M')" >> $GITHUB_OUTPUT
 
-      - name: Count New Commits On PTU # counts the commits to ptu/global.ini during the last 24 hours
-        id: new_commits_ptu
-        run: echo "NEW_COMMIT_COUNT_PTU=$(git log --oneline --since '24 hours ago' -- ptu/global.ini | wc -l)" >> $GITHUB_OUTPUT
-
-      - name: Count New Commits On LIVE # counts the commits to live/global.ini during the last 24 hours
-        id: new_commits_live
-        run: echo "NEW_COMMIT_COUNT_LIVE=$(git log --oneline --since '24 hours ago' -- live/global.ini | wc -l)" >> $GITHUB_OUTPUT
-
-      - name: Get Commit On PTU
-        id: commit_ptu
-        run: echo "COMMIT_PTU=$(git log --pretty=format:'%H' -n 1 --since '24 hours ago' -- ptu/global.ini)" >> $GITHUB_OUTPUT
-
-      - name: Get Commit On LIVE
-        id: commit_live
-        run: echo "COMMIT_LIVE=$(git log --pretty=format:'%H' -n 1 --since '24 hours ago' -- live/global.ini)" >> $GITHUB_OUTPUT
+      - name: Get Month
+        id: month
+        run: echo "MONTH=$(date '+%B')" >> $GITHUB_OUTPUT
 
       - name: Create Release Title For PTU
-        id: title_ptu # creates a title for the release that shows the version number used in the title of the last commit that changed the ptu/global.ini
+        id: title_ptu
         if: steps.new_commits_ptu.outputs.NEW_COMMIT_COUNT_PTU > 0
-#        run: echo "RELEASE_TITLE_PTU=$(cat '.github/en/ptu/build.ptu')" >> $GITHUB_OUTPUT
         run: |
-          if [$(git log -1 --pretty=%s -- ptu/global.ini | grep "|") == ""]
-          then
-          echo "RELEASE_TITLE_PTU=${{ vars.RELEASE_TITLE_PTU }}" >> $GITHUB_OUTPUT
-          else
-          echo "RELEASE_TITLE_PTU=$(git log -1 --pretty=%s -- ptu/global.ini | cut -s -d'|' -f1 | rev | cut -c 2- | rev)" >> $GITHUB_OUTPUT
-          fi
+          VERSION=$(git log -1 --pretty=%s -- ptu/global.ini | cut -s -d'|' -f1 | rev | cut -c 2- | rev)
+          echo "RELEASE_TITLE_PTU=$VERSION PTU (${{ steps.month.outputs.MONTH }})" >> $GITHUB_OUTPUT
 
       - name: Create Release Title For LIVE
-        id: title_live # creates a title for the release that shows the version number used in the title of the last commit that changed the live/global.ini
+        id: title_live
         if: steps.new_commits_live.outputs.NEW_COMMIT_COUNT_LIVE > 0
-#        run: echo "RELEASE_TITLE_LIVE=$(cat '.github/en/live/build.live')" >> $GITHUB_OUTPUT
         run: |
-          if [$(git log -1 --pretty=%s -- live/global.ini | grep "|") == ""]
-          then
-          echo "RELEASE_TITLE_LIVE=${{ vars.RELEASE_TITLE_LIVE }}" >> $GITHUB_OUTPUT
-          else
-          echo "RELEASE_TITLE_LIVE=$(git log -1 --pretty=%s -- live/global.ini | cut -s -d'|' -f1 | rev | cut -c 2- | rev)" >> $GITHUB_OUTPUT
-          fi
+          VERSION=$(git log -1 --pretty=%s -- live/global.ini | cut -s -d'|' -f1 | rev | cut -c 2- | rev)
+          echo "RELEASE_TITLE_LIVE=$VERSION LIVE (${{ steps.month.outputs.MONTH }})" >> $GITHUB_OUTPUT
 
-      - name: Get Last Tag On PTU
-        id: tag_PTU
-        run: echo "TAG_PTU=$(git tag --sort=creatordate --list '*-PTU' | tail -1)" >> $GITHUB_OUTPUT
-
-      - name: Get Last Tag On LIVE
-        id: tag_live
-        run: echo "TAG_LIVE=$(git tag --sort=creatordate --list '*-LIVE' | tail -1)" >> $GITHUB_OUTPUT
-
-      - name: Create Compare Link For PTU
-        id: link_ptu
-        run: echo "LINK_PTU=https://github.com/${{ github.repository }}/compare/${{ steps.tag_PTU.outputs.TAG_PTU }}...${{ steps.date_rev.outputs.DATE_REV }}-PTU" >> $GITHUB_OUTPUT
-
-      - name: Create Compare Link For LIVE
-        id: link_live
-        run: echo "LINK_LIVE=https://github.com/${{ github.repository }}/compare/${{ steps.tag_live.outputs.TAG_LIVE }}...${{ steps.date_rev.outputs.DATE_REV }}-LIVE" >> $GITHUB_OUTPUT
-
-      - name: Show Variables
-        id: show_variable
-        run: |
-          echo "Date: ${{ steps.date.outputs.DATE }}"
-          echo "Date Reverse: ${{ steps.date_rev.outputs.DATE_REV }}"
-          echo "Time: ${{ steps.time.outputs.TIME }}"
-          echo "New Commits On PTU: ${{ steps.new_commits_ptu.outputs.NEW_COMMIT_COUNT_PTU }}"
-          echo "New Commits On LIVE: ${{ steps.new_commits_live.outputs.NEW_COMMIT_COUNT_LIVE }}"
-          echo "Commit On PTU: ${{ steps.commit_ptu.outputs.COMMIT_PTU }}"
-          echo "Commit On LIVE: ${{ steps.commit_live.outputs.COMMIT_LIVE }}"
-          echo "Release Title PTU: ${{ steps.title_ptu.outputs.RELEASE_TITLE_PTU }}"
-          echo "Release Title LIVE: ${{ steps.title_live.outputs.RELEASE_TITLE_LIVE }}"
-          echo "Last Tag on PTU: ${{ steps.tag_PTU.outputs.TAG_PTU }}"
-          echo "Last Tag on LIVE: ${{ steps.tag_live.outputs.TAG_LIVE }}"
-          echo "Changelog Link for PTU: ${{ steps.link_ptu.outputs.LINK_PTU }}"
-          echo "Changelog Link for LIVE: ${{ steps.link_live.outputs.LINK_LIVE }}"
-
-  ptu_release: # runs only when ptu/global.ini was changed in the last 24 hours
+  ptu_release:
     name: Create PTU Release
     runs-on: ubuntu-latest
     needs: get_context_info
@@ -143,17 +89,6 @@ jobs:
         with:
           ref: ${{ needs.get_context_info.outputs.COMMIT_PTU }}
 
-      - name: Create ZIP For PTU
-        run: |
-          sudo timedatectl set-timezone Europe/Berlin
-          mkdir release
-          cp "ptu/user.cfg" "release"
-          mkdir -p "release/data/Localization/german_(germany)"
-          cp "ptu/global.ini" "release/data/Localization/german_(germany)/"
-          cd release
-          echo "${{ vars.VERSION_FILE_TEXT_PTU }} ${{ needs.get_context_info.outputs.RELEASE_TITLE_PTU }} ${{ needs.get_context_info.outputs.DATE }} - ${{ needs.get_context_info.outputs.TIME }} Uhr" >> Version.txt
-          zip -r -9 "../${{ vars.ZIP_NAME_PTU }}" *
-
       - name: Create Release For PTU
         uses: ncipollo/release-action@v1
         with:
@@ -164,7 +99,7 @@ jobs:
           body: ${{ vars.RELEASE_BODY_PTU }}(${{ needs.get_context_info.outputs.LINK_PTU }})
           artifacts: ${{ vars.ZIP_NAME_PTU }}
 
-  live_release: # runs only when live/global.ini was changed in the last 24 hours
+  live_release:
     name: Create LIVE Release
     runs-on: ubuntu-latest
     needs: [get_context_info, ptu_release]
@@ -177,19 +112,6 @@ jobs:
         with:
           ref: ${{ needs.get_context_info.outputs.COMMIT_LIVE }}
 
-      - name: Create ZIP For LIVE
-        run: |
-          sudo timedatectl set-timezone Europe/Berlin
-          mkdir release
-          cp "live/user.cfg" "release"
-          mkdir -p "release/data/Localization/german_(germany)"
-          cp "live/global.ini" "release/data/Localization/german_(germany)/"
-          cd release
-          echo "${{ vars.VERSION_FILE_TEXT_LIVE }} ${{ needs.get_context_info.outputs.RELEASE_TITLE_LIVE }} ${{ needs.get_context_info.outputs.DATE }} - ${{ needs.get_context_info.outputs.TIME }} Uhr" >> Version.txt
-          zip -r -9 "../${{ vars.ZIP_NAME_LIVE }}" *
-          cp "../live/full/global.ini" "../release/data/Localization/german_(germany)/"
-          zip -r -9 "../${{ vars.ZIP_NAME_FULL_LIVE }}" *
-
       - name: Create Release For LIVE
         uses: ncipollo/release-action@v1
         with:
@@ -200,3 +122,4 @@ jobs:
           body: ${{ vars.RELEASE_BODY_LIVE }}(${{ needs.get_context_info.outputs.LINK_LIVE }})
           artifacts: ${{ vars.ZIP_NAME_LIVE }}, ${{ vars.ZIP_NAME_FULL_LIVE }}
           makeLatest: true
+          

--- a/.github/workflows/create_realease.yml
+++ b/.github/workflows/create_realease.yml
@@ -89,6 +89,17 @@ jobs:
         with:
           ref: ${{ needs.get_context_info.outputs.COMMIT_PTU }}
 
+      - name: Create ZIP For PTU
+          run: |
+            sudo timedatectl set-timezone Europe/Berlin
+            mkdir release
+            cp "ptu/user.cfg" "release"
+            mkdir -p "release/data/Localization/german_(germany)"
+            cp "ptu/global.ini" "release/data/Localization/german_(germany)/"
+            cd release
+            echo "${{ vars.VERSION_FILE_TEXT_PTU }} ${{ needs.get_context_info.outputs.RELEASE_TITLE_PTU }} ${{ needs.get_context_info.outputs.DATE }} - ${{ needs.get_context_info.outputs.TIME }} Uhr" >> Version.txt
+            zip -r -9 "../${{ vars.ZIP_NAME_PTU }}" *
+
       - name: Create Release For PTU
         uses: ncipollo/release-action@v1
         with:
@@ -111,6 +122,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.get_context_info.outputs.COMMIT_LIVE }}
+
+      - name: Create ZIP For LIVE
+          run: |
+            sudo timedatectl set-timezone Europe/Berlin
+            mkdir release
+            cp "live/user.cfg" "release"
+            mkdir -p "release/data/Localization/german_(germany)"
+            cp "live/global.ini" "release/data/Localization/german_(germany)/"
+            cd release
+            echo "${{ vars.VERSION_FILE_TEXT_LIVE }} ${{ needs.get_context_info.outputs.RELEASE_TITLE_LIVE }} ${{ needs.get_context_info.outputs.DATE }} - ${{ needs.get_context_info.outputs.TIME }} Uhr" >> Version.txt
+            zip -r -9 "../${{ vars.ZIP_NAME_LIVE }}" *
+            cp "../live/full/global.ini" "../release/data/Localization/german_(germany)/"
+            zip -r -9 "../${{ vars.ZIP_NAME_FULL_LIVE }}" *
 
       - name: Create Release For LIVE
         uses: ncipollo/release-action@v1

--- a/.github/workflows/create_realease.yml
+++ b/.github/workflows/create_realease.yml
@@ -8,7 +8,7 @@
 # - the following steps are only run then the commit count is > 0
 # 4. create a release name with the correct version in it
 # 5. create the zip
-# 6. create the release 
+# 6. create the release
 
 name: Create Releases
 on:
@@ -90,15 +90,15 @@ jobs:
           ref: ${{ needs.get_context_info.outputs.COMMIT_PTU }}
 
       - name: Create ZIP For PTU
-          run: |
-            sudo timedatectl set-timezone Europe/Berlin
-            mkdir release
-            cp "ptu/user.cfg" "release"
-            mkdir -p "release/data/Localization/german_(germany)"
-            cp "ptu/global.ini" "release/data/Localization/german_(germany)/"
-            cd release
-            echo "${{ vars.VERSION_FILE_TEXT_PTU }} ${{ needs.get_context_info.outputs.RELEASE_TITLE_PTU }} ${{ needs.get_context_info.outputs.DATE }} - ${{ needs.get_context_info.outputs.TIME }} Uhr" >> Version.txt
-            zip -r -9 "../${{ vars.ZIP_NAME_PTU }}" *
+        run: |
+          sudo timedatectl set-timezone Europe/Berlin
+          mkdir release
+          cp "ptu/user.cfg" "release"
+          mkdir -p "release/data/Localization/german_(germany)"
+          cp "ptu/global.ini" "release/data/Localization/german_(germany)/"
+          cd release
+          echo "${{ vars.VERSION_FILE_TEXT_PTU }} ${{ needs.get_context_info.outputs.RELEASE_TITLE_PTU }} ${{ needs.get_context_info.outputs.DATE }} - ${{ needs.get_context_info.outputs.TIME }} Uhr" >> Version.txt
+          zip -r -9 "../${{ vars.ZIP_NAME_PTU }}" *
 
       - name: Create Release For PTU
         uses: ncipollo/release-action@v1
@@ -124,17 +124,17 @@ jobs:
           ref: ${{ needs.get_context_info.outputs.COMMIT_LIVE }}
 
       - name: Create ZIP For LIVE
-          run: |
-            sudo timedatectl set-timezone Europe/Berlin
-            mkdir release
-            cp "live/user.cfg" "release"
-            mkdir -p "release/data/Localization/german_(germany)"
-            cp "live/global.ini" "release/data/Localization/german_(germany)/"
-            cd release
-            echo "${{ vars.VERSION_FILE_TEXT_LIVE }} ${{ needs.get_context_info.outputs.RELEASE_TITLE_LIVE }} ${{ needs.get_context_info.outputs.DATE }} - ${{ needs.get_context_info.outputs.TIME }} Uhr" >> Version.txt
-            zip -r -9 "../${{ vars.ZIP_NAME_LIVE }}" *
-            cp "../live/full/global.ini" "../release/data/Localization/german_(germany)/"
-            zip -r -9 "../${{ vars.ZIP_NAME_FULL_LIVE }}" *
+        run: |
+          sudo timedatectl set-timezone Europe/Berlin
+          mkdir release
+          cp "live/user.cfg" "release"
+          mkdir -p "release/data/Localization/german_(germany)"
+          cp "live/global.ini" "release/data/Localization/german_(germany)/"
+          cd release
+          echo "${{ vars.VERSION_FILE_TEXT_LIVE }} ${{ needs.get_context_info.outputs.RELEASE_TITLE_LIVE }} ${{ needs.get_context_info.outputs.DATE }} - ${{ needs.get_context_info.outputs.TIME }} Uhr" >> Version.txt
+          zip -r -9 "../${{ vars.ZIP_NAME_LIVE }}" *
+          cp "../live/full/global.ini" "../release/data/Localization/german_(germany)/"
+          zip -r -9 "../${{ vars.ZIP_NAME_FULL_LIVE }}" *
 
       - name: Create Release For LIVE
         uses: ncipollo/release-action@v1
@@ -146,4 +146,3 @@ jobs:
           body: ${{ vars.RELEASE_BODY_LIVE }}(${{ needs.get_context_info.outputs.LINK_LIVE }})
           artifacts: ${{ vars.ZIP_NAME_LIVE }}, ${{ vars.ZIP_NAME_FULL_LIVE }}
           makeLatest: true
-          

--- a/.github/workflows/create_realease.yml
+++ b/.github/workflows/create_realease.yml
@@ -12,13 +12,17 @@
 
 name: Create Releases
 on:
-  workflow_dispatch:
+  workflow_dispatch: # used only to manually trigger the workflow from the GitHub website
     inputs:
       tag:
         description: "Release Tag"
         type: string
-  schedule:
+  schedule: # 3 am every 14 days
     - cron: "0 3 */14 * *"
+  push:
+    branches:
+      - main
+
 jobs:
   get_context_info:
     name: Get Context Info
@@ -36,6 +40,8 @@ jobs:
       RELEASE_TITLE_LIVE: ${{ steps.title_live.outputs.RELEASE_TITLE_LIVE }}
       LINK_PTU: ${{ steps.link_ptu.outputs.LINK_PTU }}
       LINK_LIVE: ${{ steps.link_live.outputs.LINK_LIVE }}
+      VERSION_CHANGED_PTU: ${{ steps.version_jump_ptu.outputs.VERSION_CHANGED_PTU }}
+      VERSION_CHANGED_LIVE: ${{ steps.version_jump_live.outputs.VERSION_CHANGED_LIVE }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -44,7 +50,10 @@ jobs:
 
       - name: Set Timezone
         id: timezone
-        run: sudo timedatectl set-timezone Europe/Berlin
+        run: |
+          sudo timedatectl set-timezone Europe/Berlin
+          sudo apt install -y locales
+          sudo locale-gen de_DE.UTF-8
 
       - name: Get Date
         id: date
@@ -60,27 +69,107 @@ jobs:
 
       - name: Get Month
         id: month
-        run: echo "MONTH=$(date '+%B')" >> $GITHUB_OUTPUT
+        run: echo "MONTH=$(LC_ALL="de_DE.UTF-8" date '+%B')" >> $GITHUB_OUTPUT
 
+      - name: Count New Commits On PTU # counts the commits to ptu/global.ini during the last 14 days
+        id: new_commits_ptu
+        run: echo "NEW_COMMIT_COUNT_PTU=$(git log --oneline --since '14 days ago' -- ptu/global.ini | wc -l)" >> $GITHUB_OUTPUT
+
+      - name: Count New Commits On LIVE # counts the commits to live/global.ini during the last 14 days
+        id: new_commits_live
+        run: echo "NEW_COMMIT_COUNT_LIVE=$(git log --oneline --since '14 days ago' -- live/global.ini | wc -l)" >> $GITHUB_OUTPUT
+
+      - name: Get Commit On PTU
+        id: commit_ptu
+        run: echo "COMMIT_PTU=$(git log --pretty=format:'%H' -n 1 --since '14 days ago' -- ptu/global.ini)" >> $GITHUB_OUTPUT
+
+      - name: Get Commit On LIVE
+        id: commit_live
+        run: echo "COMMIT_LIVE=$(git log --pretty=format:'%H' -n 1 --since '14 days ago' -- live/global.ini)" >> $GITHUB_OUTPUT
       - name: Create Release Title For PTU
-        id: title_ptu
+        id: title_ptu # creates a title for the release that shows the version number used in the title of the last commit that changed the ptu/global.ini
         if: steps.new_commits_ptu.outputs.NEW_COMMIT_COUNT_PTU > 0
         run: |
-          VERSION=$(git log -1 --pretty=%s -- ptu/global.ini | cut -s -d'|' -f1 | rev | cut -c 2- | rev)
-          echo "RELEASE_TITLE_PTU=$VERSION PTU (${{ steps.month.outputs.MONTH }})" >> $GITHUB_OUTPUT
-
+          if [$(git log -1 --pretty=%s -- ptu/global.ini | grep "|") == ""]
+          then
+          echo "RELEASE_TITLE_PTU=${{ vars.RELEASE_TITLE_PTU }} (${{ steps.month.outputs.MONTH }})" >> $GITHUB_OUTPUT
+          else
+          echo "RELEASE_TITLE_PTU=$(git log -1 --pretty=%s -- ptu/global.ini | cut -s -d'|' -f1 | rev | cut -c 2- | rev | cut -s -d' ' -f1) PTU (${{ steps.month.outputs.MONTH }})" >> $GITHUB_OUTPUT
+          fi
       - name: Create Release Title For LIVE
-        id: title_live
+        id: title_live # creates a title for the release that shows the version number used in the title of the last commit that changed the live/global.ini
         if: steps.new_commits_live.outputs.NEW_COMMIT_COUNT_LIVE > 0
         run: |
-          VERSION=$(git log -1 --pretty=%s -- live/global.ini | cut -s -d'|' -f1 | rev | cut -c 2- | rev)
-          echo "RELEASE_TITLE_LIVE=$VERSION LIVE (${{ steps.month.outputs.MONTH }})" >> $GITHUB_OUTPUT
+          if [$(git log -1 --pretty=%s -- live/global.ini | grep "|") == ""]
+          then
+          echo "RELEASE_TITLE_LIVE=${{ vars.RELEASE_TITLE_LIVE }} (${{ steps.month.outputs.MONTH }})" >> $GITHUB_OUTPUT
+          else
+          echo "RELEASE_TITLE_LIVE=$(git log -1 --pretty=%s -- live/global.ini | cut -s -d'|' -f1 | rev | cut -c 2- | rev | cut -s -d' ' -f1) LIVE (${{ steps.month.outputs.MONTH }})" >> $GITHUB_OUTPUT
+          fi
 
-  ptu_release:
+      - name: Get Last Tag On PTU
+        id: tag_PTU
+        run: echo "TAG_PTU=$(git tag --sort=creatordate --list '*-PTU' | tail -1)" >> $GITHUB_OUTPUT
+
+      - name: Get Last Tag On LIVE
+        id: tag_live
+        run: echo "TAG_LIVE=$(git tag --sort=creatordate --list '*-LIVE' | tail -1)" >> $GITHUB_OUTPUT
+
+      - name: Create Compare Link For PTU
+        id: link_ptu
+        run: echo "LINK_PTU=https://github.com/${{ github.repository }}/compare/${{ steps.tag_PTU.outputs.TAG_PTU }}...${{ steps.date_rev.outputs.DATE_REV }}-PTU" >> $GITHUB_OUTPUT
+
+      - name: Create Compare Link For LIVE
+        id: link_live
+        run: echo "LINK_LIVE=https://github.com/${{ github.repository }}/compare/${{ steps.tag_live.outputs.TAG_LIVE }}...${{ steps.date_rev.outputs.DATE_REV }}-LIVE" >> $GITHUB_OUTPUT
+
+      - name: Version Jump PTU
+        id: version_jump_ptu
+        run: |
+          PREV_VERSION=$(git log -2 --pretty=%s -- ptu/global.ini | tail -1 | cut -s -d'|' -f1 | rev | cut -c 2- | rev | cut -s -d' ' -f1)
+          CURR_VERSION=$(git log -1 --pretty=%s -- ptu/global.ini | cut -s -d'|' -f1 | rev | cut -c 2- | rev | cut -s -d' ' -f1)
+          if [ "$PREV_VERSION" != "$CURR_VERSION" ]; then
+            echo "VERSION_CHANGED_PTU=true" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION_CHANGED_PTU=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Version Jump LIVE
+        id: version_jump_live
+        run: |
+          PREV_VERSION=$(git log -2 --pretty=%s -- live/global.ini | tail -1 | cut -s -d'|' -f1 | rev | cut -c 2- | rev | cut -s -d' ' -f1)
+          CURR_VERSION=$(git log -1 --pretty=%s -- live/global.ini | cut -s -d'|' -f1 | rev | cut -c 2- | rev | cut -s -d' ' -f1)
+          if [ "$PREV_VERSION" != "$CURR_VERSION" ]; then
+            echo "VERSION_CHANGED_LIVE=true" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION_CHANGED_LIVE=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Show Variables
+        id: show_variable
+        run: |
+          echo "Date: ${{ steps.date.outputs.DATE }}"
+          echo "Date Reverse: ${{ steps.date_rev.outputs.DATE_REV }}"
+          echo "Time: ${{ steps.time.outputs.TIME }}"
+          echo "Month: ${{ steps.month.outputs.MONTH }}"
+          echo "New Commits On PTU: ${{ steps.new_commits_ptu.outputs.NEW_COMMIT_COUNT_PTU }}"
+          echo "New Commits On LIVE: ${{ steps.new_commits_live.outputs.NEW_COMMIT_COUNT_LIVE }}"
+          echo "Commit On PTU: ${{ steps.commit_ptu.outputs.COMMIT_PTU }}"
+          echo "Commit On LIVE: ${{ steps.commit_live.outputs.COMMIT_LIVE }}"
+          echo "Release Title PTU: ${{ steps.title_ptu.outputs.RELEASE_TITLE_PTU }}"
+          echo "Release Title LIVE: ${{ steps.title_live.outputs.RELEASE_TITLE_LIVE }}"
+          echo "Last Tag on PTU: ${{ steps.tag_PTU.outputs.TAG_PTU }}"
+          echo "Last Tag on LIVE: ${{ steps.tag_live.outputs.TAG_LIVE }}"
+          echo "Changelog Link for PTU: ${{ steps.link_ptu.outputs.LINK_PTU }}"
+          echo "Changelog Link for LIVE: ${{ steps.link_live.outputs.LINK_LIVE }}"
+          echo "Version Jump PTU: ${{ steps.version_jump_ptu.outputs.VERSION_CHANGED_PTU }}"
+          echo "Version Jump LIVE: ${{ steps.version_jump_live.outputs.VERSION_CHANGED_LIVE }}"
+
+  ptu_release: # runs only when ptu/global.ini was changed in the last 14 days or the version number was changed
     name: Create PTU Release
     runs-on: ubuntu-latest
     needs: get_context_info
-    if: (vars.TRIGGER_PTU_RELEASE == 1) && (needs.get_context_info.outputs.NEW_COMMIT_COUNT_PTU > 0)
+    if: (vars.TRIGGER_PTU_RELEASE == 1) && (((github.event_name == 'schedule') && (needs.get_context_info.outputs.NEW_COMMIT_COUNT_PTU > 0)) || ((github.event_name == 'push') && (needs.get_context_info.outputs.VERSION_CHANGED_PTU == 'true')) || (github.event_name == 'workflow_dispatch'))
     permissions:
       contents: write
     steps:
@@ -110,11 +199,11 @@ jobs:
           body: ${{ vars.RELEASE_BODY_PTU }}(${{ needs.get_context_info.outputs.LINK_PTU }})
           artifacts: ${{ vars.ZIP_NAME_PTU }}
 
-  live_release:
+  live_release: # runs only when live/global.ini was changed in the last 14 days or the version number was changed
     name: Create LIVE Release
     runs-on: ubuntu-latest
     needs: [get_context_info, ptu_release]
-    if: always() && (needs.get_context_info.outputs.NEW_COMMIT_COUNT_LIVE > 0)
+    if: always() && (((github.event_name == 'schedule') && (needs.get_context_info.outputs.NEW_COMMIT_COUNT_LIVE > 0)) || ((github.event_name == 'push') && (needs.get_context_info.outputs.VERSION_CHANGED_LIVE == 'true')) || (github.event_name == 'workflow_dispatch'))
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
- Workflow alle 14 Tage
- Sofortiger Release bei Versionssprung. Beispiel 4.0.1 -> 4.0.2
- Titel zu beispielsweise `4.0.2 LIVE (Februar)`